### PR TITLE
Access pure eloquent entity instead of builder.

### DIFF
--- a/src/Bosnadev/Repositories/Eloquent/Repository.php
+++ b/src/Bosnadev/Repositories/Eloquent/Repository.php
@@ -245,6 +245,15 @@ abstract class Repository implements RepositoryInterface, CriteriaInterface
     }
 
     /**
+     * Returns clean entity of model
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function entity()
+    {
+        return $this->newModel;
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Builder
      * @throws RepositoryException
      */


### PR DESCRIPTION
Added method which allows to access eloquent model without refferencing to builder.
It's relevant for accessing model's data, eg:  $model->getTable() - while it is not available while having builder refference